### PR TITLE
Applied tooltip-key-metrics to key financial metrics

### DIFF
--- a/src/components/stock-info/StockInfo.tsx
+++ b/src/components/stock-info/StockInfo.tsx
@@ -207,22 +207,22 @@ const StockInfo = ({ stockOverview, stockBalanceSheet, stockCashFlow, stockIncom
                             <tbody>
                                 <tr>
                                     <Tippy content="Current price the stock is trading at in the market">
-                                        <th>Market Price</th>
+                                        <th className="tooltip-key-metrics">Market Price</th>
                                     </Tippy>
                                     <Tippy content="Company's profits divided by all existing shares. The higher EPS the better">
-                                        <th>EPS</th>
+                                        <th className="tooltip-key-metrics">EPS</th>
                                     </Tippy>
                                     <Tippy content="Ratio of how well a company is using its resources to make money. 10% or more is good">
-                                        <th>Return on Invested Capital (ROIC)</th>
+                                        <th className="tooltip-key-metrics">Return on Invested Capital (ROIC)</th>
                                     </Tippy>
                                     <Tippy content="Measures how much operating income is generated relative to interest expense. 6% or more is good">
-                                        <th>Interest Coverage Ratio</th>
+                                        <th className="tooltip-key-metrics">Interest Coverage Ratio</th>
                                     </Tippy>
                                     <Tippy content="How long it would take a company to pay off all its debts. The lower the better">
-                                        <th>Debt Payback Time</th>
+                                        <th className="tooltip-key-metrics">Debt Payback Time</th>
                                     </Tippy>
                                     <Tippy content="Ratio of price to earnings. Measures how cheap or expensive a stock is. Generally, (depending on the industrial) 15% or less is cheap and more than 15% is expensive">
-                                        <th>PE Ratio</th>
+                                        <th className="tooltip-key-metrics">PE Ratio</th>
                                     </Tippy>
                                 </tr>
                                 <tr>

--- a/src/components/stock-info/stock-info.css
+++ b/src/components/stock-info/stock-info.css
@@ -39,6 +39,14 @@ body {
   width: 100%;
 }
 
+.tooltip-key-metrics {
+  color: blue;
+  text-decoration: dotted;
+  text-decoration-color: black;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+}
+
 .welcome-box {
   position: relative;
   color: black;


### PR DESCRIPTION
Purpose of this pull request is to add styling to the key metrics. The key metrics text already has a tooltip but it is not obvious to the user that you can hover over the text. I added styling which added a dotted underline under key metrics text and changed its color to blue. That way users can see the text is hoverable.