### PR TITLE
Added Error Checker for Invalid Stock Ticker

### DIFF
--- a/src/components/search-bar/SearchBar.tsx
+++ b/src/components/search-bar/SearchBar.tsx
@@ -21,6 +21,8 @@ const SearchBar = ({
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const [valid, setValid] = useState(false);
+
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
@@ -33,7 +35,16 @@ const SearchBar = ({
    */
   const search = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === "Enter") {
+      setValid(false); // Assumed invalid stock ticker until otherwise.
       getOverview();
+
+      // Exit search function if data from overview is empty. No use in making other API calls.
+      if(!valid)
+      {
+        setQuery("");
+        return;
+      }
+      
       getBalanceSheet();
       getCashFlow();
       getIncomeStatement();
@@ -47,6 +58,7 @@ const SearchBar = ({
           `${alphaVantageAPI}function=OVERVIEW&symbol=${query}&apikey=${REACT_APP_ALPHA_VANTAGE_ACCESS_KEY}`
         )
         .then((response: AxiosResponse<any>) => {
+          setValid(true); // There is a response based on stock ticker so valid.
           stockOverview(response.data);
           //console.log("OVERVIEW");
           //console.log(response.data);


### PR DESCRIPTION
Added error checking if stock ticker returns an empty array when doing the overview API call then return. Do not make other useless API calls.

In SearchBar component, I created a hook called valid with its function setValid. It is by default false. It is true whenever the user input stock ticker returns data showing that it is a valid stock ticker.